### PR TITLE
Set up TTL for row primary keys with the lowest TTL value of all non-key cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Select an Azure Databricks runtime version which supports Spark 3.0 or higher.
 
 ## Add Cassandra Migrator Spark dependencies
 
-* Download the dependency jar [here](https://github.com/Azure-Samples/cassandra-migrator/raw/main/jar/cassandra-migrator-assembly-0.0.2.jar) * 
+* Download the dependency jar [here](https://github.com/Azure-Samples/cassandra-migrator/raw/main/jar/cassandra-migrator-assembly-0.0.3.jar) * 
 * Upload and install the jar on your Databricks cluster:
 
 <!-- :::image type="content" source="./media/cassandra-migrator-jar.jpg" alt-text="Screenshot that shows searching for Maven packages in Databricks."::: -->

--- a/build_files/build.sbt
+++ b/build_files/build.sbt
@@ -1,6 +1,3 @@
-
-
-
 assemblyMergeStrategy in assembly := {
   case "module-info.class" => MergeStrategy.discard
   case x =>

--- a/build_files/build.sbt
+++ b/build_files/build.sbt
@@ -1,4 +1,4 @@
-import sbt.librarymanagement.InclExclRule
+
 
 
 assemblyMergeStrategy in assembly := {
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).settings(
       scalaVersion := "2.12.11"
     )),
   name      := "cassandra-migrator",
-  version   := "0.0.2",
+  version   := "0.0.3",
   mainClass := Some("com.cassandra.migrator.Migrator"),
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   javaOptions ++= Seq(

--- a/build_files/src/main/scala/com/cassandra/migrator/readers/Cassandra.scala
+++ b/build_files/src/main/scala/com/cassandra/migrator/readers/Cassandra.scala
@@ -145,9 +145,8 @@ object Cassandra {
             Row(newValues: _*)
         }
 
-      // If there are multiple inserts, add one more insert that only inserts ids using max writetime and min ttl.
+      // If there are multiple inserts, add one more insert that only inserts ids using min ttl.
       val minTTL = timestampsToFields.map(_._1._1).minBy(_.getOrElse(Int.MaxValue))
-      val maxWriteTime = timestampsToFields.map(_._1._2).maxBy(_.getOrElse(Long.MinValue))
       if (rows.size > 1 && minTTL.isDefined) {
         val newValues = schema.fields.map { field =>
           primaryKeyOrdinals
@@ -157,7 +156,7 @@ object Cassandra {
               else Some(row.get(ord))
             }
             .getOrElse(CassandraOption.Unset)
-        } ++ Seq(minTTL.get, maxWriteTime.getOrElse(CassandraOption.Unset))
+        } ++ Seq(minTTL.get, CassandraOption.Unset)
 
         rows = rows ++ List(Row(newValues: _*))
       }

--- a/build_files/src/main/scala/com/cassandra/migrator/readers/Cassandra.scala
+++ b/build_files/src/main/scala/com/cassandra/migrator/readers/Cassandra.scala
@@ -125,11 +125,6 @@ object Cassandra {
         else rowTimestampsToFields
 
       var rows = timestampsToFields
-        .toList
-        // sort all inserts by ttl in the descending order, such that the last insert has the lowest ttl.
-        // If insert without using TTL, this row is live and won't be deleted despite all its cells are
-        // null. In order to avoid all cells are null but the row exists, we need to put it first.
-        .sortBy(row => -row._1._1.getOrElse(Int.MaxValue))
         .map {
           case ((ttl, writetime), fields) =>
             val newValues = schema.fields.map { field =>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This migrator is unable to know the true value of the ttl of the primary keys because cql statements only support selecting ttl for the non-key cells. Thus, ttl is determined by the insert statements. We need to keep the ttl of the primary keys as low as possible, because a row could be alive despite all cells are expired when the ttl of the primary keys are larger than other cells, which is unexpected. 

We first camp up with a solution that is to order all inserts for a row, such that the last insert has the lowest value of ttl because we thought the ttl of the primary key is determined by the last insert we do. But the truth is that the ttl of primary key is determined by the following rules: 
* If the writetime of the incoming insert is earlier than the existing writetime, the incoming insert will be ignored. Thus, the insert statement with the latest writetime determines the ttl of the primary keys. 
* If the writetime of the incoming insert is the same as the existing writetime, ttl will be the larger value between the ttl in the incoming insert and the existing ttl. 

Thus, the order of inserts won't affect ttl. In order to set up ttl with a given value, we need one more insert using the given ttl and a writetime larger than all writetime of all cells. In this PR, we add one more insert using the lowest ttl value of all non-key cells without specifying writetime, because Cassandra would use now timestamp as writetime if it's not set.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. Execute several inserts for the same row with different ttl and writetime. 
2. Migrate with this migrator.
3. sstabledump the target table to see the ttl of the primary keys. 
```

## What to Check
Verify that the following are valid
* the ttl of the primary keys is the lowest among the ttl of all the cells.

## Other Information
<!-- Add any other helpful information that may be needed here. -->